### PR TITLE
1.0.2 live

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,14 @@ setup :
 
 `npm run start (launches program with nodemon)`
 
+## New in 1.0.2 !
+* Set the output method of the getReviews method with an optional second argument : "json" or "object". The default is "json".
+
 ## Description
 This project aims to scrape data from the google maps business page in order to get the reviews
 (it's not in the api, why google ?)
+
+
 ### Technologies used
 * Puppeteer
 * Express

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "google-reviews-web-scraper",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Retrieves google reviews through a web scraper and returns it as a json array",
   "main": "getReviews.js",
   "scripts": {

--- a/src/getReviews.js
+++ b/src/getReviews.js
@@ -1,6 +1,11 @@
 const puppeteer  = require('puppeteer');
 
 const getReviews = async (url, output = "json") => {
+    output = output.toLowerCase();
+    if (output != "json" && output != "object") {
+        console.error('INVALID OUTPUT OPTION');
+        return;
+    }
     console.log('Launching headless chrome...');
     url = url.toString();
     const browser = await puppeteer.launch({args: ['--disabled-setuid-sandbox', '--no-sandbox']});

--- a/src/getReviews.js
+++ b/src/getReviews.js
@@ -1,6 +1,6 @@
 const puppeteer  = require('puppeteer');
 
-const getReviews = async (url) => {
+const getReviews = async (url, output = "json") => {
     console.log('Launching headless chrome...');
     url = url.toString();
     const browser = await puppeteer.launch({args: ['--disabled-setuid-sandbox', '--no-sandbox']});
@@ -45,7 +45,11 @@ const getReviews = async (url) => {
     browser.close();
     console.log(data);
     return new Promise((resolve, reject) => {
-        resolve(data);
+        if(output === "json") {
+            resolve(JSON.stringify(data));
+        } else if(output === "object") {
+            resolve(data);
+        }
         if(reject) {
             reject({error: "error while scraping data."})
         }


### PR DESCRIPTION
New in 1.0.2 !

- Set the output method of the getReviews method with an optional second argument : "json" or "object". The default is "json".
`getReviews(url, output = "json")`